### PR TITLE
chore: bump jwt/v5 + exclude Claude context (v0.0.10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ references/
 main
 util
 .env*
+
+# ── Claude Code (public repo — internal context 노출 방지) ──
+.claude/
+CLAUDE.md
+claude-memory/

--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,28 @@ src/gopkg.in/
 go.work
 go.work.sum
 
+# Editor/IDE
+.idea/
+.vscode/
+
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-1000/
+
+ # macOS system files
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+
+# References for code snippets
+references/
+
 # MARK
 main
 util
-.vscode/
-.vscode
-.idea/
 .env*
-.DS_Store

--- a/config.go
+++ b/config.go
@@ -1,6 +1,8 @@
 package util
 
-import "time"
+import (
+	"time"
+)
 
 type TelegramBotConfig interface {
 	SendMessageAt(message string, at ...time.Time)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/Cellularhacker/util-go
 go 1.25
 
 require (
-	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jinzhu/now v1.1.5
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/Cellularhacker/util-go
 go 1.25
 
 require (
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/jinzhu/now v1.1.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
-github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
-github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=

--- a/main.go
+++ b/main.go
@@ -1,8 +1,12 @@
 package util
 
-import "time"
+import (
+	"time"
+)
 
-var Loc *time.Location
+var (
+	Loc *time.Location
+)
 
 func init() {
 

--- a/simpleGraphQL/store.go
+++ b/simpleGraphQL/store.go
@@ -1,6 +1,8 @@
 package simpleGraphQL
 
-import "strconv"
+import (
+	"strconv"
+)
 
 func GetLatestDataPoints(dps []DataPoints) *DataPoints {
 	if len(dps) == 0 {

--- a/token/token.go
+++ b/token/token.go
@@ -2,7 +2,8 @@ package token
 
 import (
 	"fmt"
-	"github.com/golang-jwt/jwt"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 var (

--- a/uStrings/strings.go
+++ b/uStrings/strings.go
@@ -1,6 +1,8 @@
 package uStrings
 
-import "strings"
+import (
+	"strings"
+)
 
 func RemoveAndTrim(original string, targets ...string) string {
 	str := original

--- a/uTime/date.go
+++ b/uTime/date.go
@@ -2,10 +2,11 @@ package uTime
 
 import (
 	"fmt"
-	"github.com/Cellularhacker/util-go"
-	"github.com/jinzhu/now"
 	"strconv"
 	"time"
+
+	"github.com/Cellularhacker/util-go"
+	"github.com/jinzhu/now"
 )
 
 func GetNowDate() int {

--- a/uTime/time.go
+++ b/uTime/time.go
@@ -2,9 +2,10 @@ package uTime
 
 import (
 	"fmt"
-	"github.com/Cellularhacker/util-go"
 	"strconv"
 	"time"
+
+	"github.com/Cellularhacker/util-go"
 )
 
 const baseDayOfWeek = 1 //Monday

--- a/uTime/timeCheck.go
+++ b/uTime/timeCheck.go
@@ -1,6 +1,8 @@
 package uTime
 
-import "time"
+import (
+	"time"
+)
 
 func IsNewHour() bool {
 	loc, _ := time.LoadLocation("Asia/Seoul")


### PR DESCRIPTION
## Summary
- chore(deps): bump `golang-jwt/jwt/v5` v5.3.0 → v5.3.1
- chore(gitignore): exclude `.claude/`, `CLAUDE.md`, `claude-memory/` (public repo 노출 방지)
- 기 commit: code convention, .gitignore base

## Test plan
- [x] `go build ./...` 통과
- [x] `go test ./...` (test 없음)

차후 v0.0.10 으로 릴리스.